### PR TITLE
Process 'extras' only if they are set

### DIFF
--- a/CloudFlare/__init__.py
+++ b/CloudFlare/__init__.py
@@ -195,5 +195,6 @@ class CloudFlare(object):
 
 	# add the API calls
 	api_v4(self)
-	api_extras(self, extras)
+	if extras:
+		api_extras(self, extras)
 

--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -37,7 +37,8 @@ def read_configs():
 	except:
 		extras = None
 
-	extras = extras.split(' ')
+	if extras:
+		extras = extras.split(' ')
 
 	return [ email, token, certtoken, extras ]
 


### PR DESCRIPTION
If extras are not configured, the code fails in 2 places when trying to read_configs(). This patch skips trying to call .split() on a None object.