### PR TITLE
Fixed empty extras field

### DIFF
--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -11,6 +11,7 @@ def read_configs():
     email = os.getenv('CF_API_EMAIL')
     token = os.getenv('CF_API_KEY')
     certtoken = os.getenv('CF_API_CERTKEY')
+    extras = os.getenv('CF_API_EXTRAS')
 
     # grab values from config files
     config = ConfigParser.RawConfigParser()
@@ -41,7 +42,7 @@ def read_configs():
 
     try:
         extras = re.sub(r"\s+", ' ', config.get('CloudFlare', 'extras'))
-    except ConfigParser.NoOptionError:
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         extras = None
 
     if extras:


### PR DESCRIPTION
Fixed empty extras field so now you don't need the cloudflare.cfg file anymore:

Without this fix you always need the .cloudflare/cloudflare.cfg file with the extras field set, even if you don't use it. 

With this fix this isn't necessary anymore and only shell variables are required.