### PR TITLE
Fix handling of missing config when passing in email and token.

### DIFF
--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -21,10 +21,11 @@ def read_configs():
     ])
 
     if email is None:
-        email = config.get('CloudFlare', 'email')
         try:
             email = re.sub(r"\s+", '', config.get('CloudFlare', 'email'))
         except ConfigParser.NoOptionError:
+            email = None
+        except ConfigParser.NoSectionError:
             email = None
 
     if token is None:
@@ -32,16 +33,22 @@ def read_configs():
             token = re.sub(r"\s+", '', config.get('CloudFlare', 'token'))
         except ConfigParser.NoOptionError:
             token = None
+        except ConfigParser.NoSectionError:
+            token = None
 
     if certtoken is None:
         try:
             certtoken = re.sub(r"\s+", '', config.get('CloudFlare', 'certtoken'))
         except ConfigParser.NoOptionError:
             certtoken = None
+        except ConfigParser.NoSectionError:
+            certtoken = None
 
     try:
         extras = re.sub(r"\s+", ' ', config.get('CloudFlare', 'extras'))
     except ConfigParser.NoOptionError:
+        extras = None
+    except ConfigParser.NoSectionError:
         extras = None
 
     if extras:


### PR DESCRIPTION
I intend to pass in the email and token rather than using environment settings or config files. The config parser was failing due to the missing config file and not properly catching the exception.

Problem code in https://github.com/cloudflare/python-cloudflare/blob/master/CloudFlare/read_configs.py with my notes added:

<pre>
    if email is None:
        # (nicholaskuechler) this will never be used.
        email = config.get('CloudFlare', 'email')
        try:
            # (nicholaskuechler) the CloudFlare section does not exist because
            # the config does not exist. But the exception is NoSectionError,
            # which is not being caught.
            email = re.sub(r"\s+", '', config.get('CloudFlare', 'email'))
        except ConfigParser.NoOptionError:
            email = None
</pre>

Exception raised, but not caught:
`ConfigParser.NoSectionError: No section: 'CloudFlare'`

Reproduce:
<pre>
>>> import os
>>> import ConfigParser
>>> config = ConfigParser.RawConfigParser()
>>> config.read([
...     '.cloudflare.cfg',
...     os.path.expanduser('~/.cloudflare.cfg'),
...     os.path.expanduser('~/.cloudflare/cloudflare.cfg')
... ])
[]
>>> email = os.getenv('CF_API_EMAIL')
>>> if email is None:
...     email = config.get('CloudFlare', 'email')
...     try:
...         email = re.sub(r"\s+", '', config.get('CloudFlare', 'email'))
...     except ConfigParser.NoOptionError:
...         email = None
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ConfigParser.py", line 330, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'CloudFlare'
</pre>