### PR TITLE
Fix fail parse config if no section

### DIFF
--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -21,27 +21,26 @@ def read_configs():
     ])
 
     if email is None:
-        email = config.get('CloudFlare', 'email')
         try:
             email = re.sub(r"\s+", '', config.get('CloudFlare', 'email'))
-        except ConfigParser.NoOptionError:
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             email = None
 
     if token is None:
         try:
             token = re.sub(r"\s+", '', config.get('CloudFlare', 'token'))
-        except ConfigParser.NoOptionError:
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             token = None
 
     if certtoken is None:
         try:
             certtoken = re.sub(r"\s+", '', config.get('CloudFlare', 'certtoken'))
-        except ConfigParser.NoOptionError:
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             certtoken = None
 
     try:
         extras = re.sub(r"\s+", ' ', config.get('CloudFlare', 'extras'))
-    except ConfigParser.NoOptionError:
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
         extras = None
 
     if extras:


### PR DESCRIPTION
Hello,

The library is unusable without config files ```.cloudflare.cfg``` or ```~/.cloudflare.cfg``` or ```~/.cloudflare/cloudflare.cfg``` due fails to parse missing config file. There is no way for example use email and token in class constructor, due continuing fail to parse missing config file.

Example stacktrace:
```pytb
Traceback (most recent call last):
  File "ls.py", line 20, in <module>
    main()
  File "ls.py", line 5, in main
    token='XXX')
  File "/tmp/cloudflare-listing/env/local/lib/python2.7/site-packages/CloudFlare/cloudflare.py", line 346, in __init__
    [conf_email, conf_token, conf_certtoken, extras] = read_configs()
  File "/tmp/cloudflare-listing/env/local/lib/python2.7/site-packages/CloudFlare/read_configs.py", line 45, in read_configs
    certtoken = re.sub(r"\s+", '', config.get('CloudFlare', 'certtoken'))
  File "/usr/lib/python2.7/ConfigParser.py", line 330, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'CloudFlare'
```