### PR TITLE
Remove Broken Import

### DIFF
--- a/CloudFlare/__init__.py
+++ b/CloudFlare/__init__.py
@@ -1,5 +1,3 @@
 """ CloudFlare v4 API"""
 
-from cloudflare import CloudFlare
-
 __version__ = '1.1.5'


### PR DESCRIPTION
The `CloudFlare` import in `__init__.py` appears to be unnecessary and is causing difficulties when installing.

```
Collecting cloudflare (from -r requirements.txt (line 12))
  Using cached cloudflare-1.1.5.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/6f/95l6m3j50cg11nzjbg87gg800000gn/T/pip-build-PQ7Smp/cloudflare/setup.py", line 5, in <module>
        from CloudFlare import __version__
      File "CloudFlare/__init__.py", line 3, in <module>
        from cloudflare import CloudFlare
      File "CloudFlare/cloudflare.py", line 5, in <module>
        import requests
    ImportError: No module named requests
```