### PR TITLE
Code adapted for Python 3

### DIFF
--- a/CloudFlare/__init__.py
+++ b/CloudFlare/__init__.py
@@ -1,8 +1,11 @@
 """ Cloudflare v4 API"""
 
+from __future__ import absolute_import
+
 try:
-    from cloudflare import CloudFlare
+    from .cloudflare import CloudFlare
 except:
     pass
+
 
 __version__ = '1.3.1'

--- a/CloudFlare/api_extras.py
+++ b/CloudFlare/api_extras.py
@@ -1,6 +1,9 @@
 """ API extras for Cloudflare API"""
 
+from __future__ import absolute_import
+
 import re
+
 
 def api_extras(self, extras=None):
     """ API extras for Cloudflare API"""
@@ -54,4 +57,3 @@ def api_extras(self, extras=None):
                 setattr(current, element,
                         self._add_with_auth(self._base, api_call_part1))
             current = getattr(current, element)
-

--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -1,5 +1,6 @@
 """ API core commands for Cloudflare API"""
 
+
 def api_v4(self):
     """ API core commands for Cloudflare API"""
 

--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -1,17 +1,19 @@
 """ Cloudflare v4 API"""
 
+from __future__ import absolute_import
+
 import json
-import urllib
 import requests
 
-from logger import Logger
-from utils import sanitize_secrets
-from read_configs import read_configs
-from api_v4 import api_v4
-from api_extras import api_extras
-from exceptions import CloudFlareError, CloudFlareAPIError, CloudFlareInternalError
+from .api_extras import api_extras
+from .api_v4 import api_v4
+from .exceptions import CloudFlareAPIError, CloudFlareInternalError
+from .logger import Logger
+from .read_configs import read_configs
+from .utils import sanitize_secrets
 
 BASE_URL = 'https://api.cloudflare.com/client/v4'
+
 
 class CloudFlare(object):
     """ Cloudflare v4 API"""
@@ -235,27 +237,27 @@ class CloudFlare(object):
         def get(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'get() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'get() call not available for this endpoint')
 
         def patch(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'patch() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'patch() call not available for this endpoint')
 
         def post(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'post() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'post() call not available for this endpoint')
 
         def put(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'put() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'put() call not available for this endpoint')
 
         def delete(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'delete() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'delete() call not available for this endpoint')
 
     class _add_noauth(object):
         """ Cloudflare v4 API"""
@@ -272,31 +274,31 @@ class CloudFlare(object):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_no_auth('GET',
-                                               self.api_call_part1,
-                                               self.api_call_part2,
-                                               self.api_call_part3,
-                                               identifier1, identifier2,
-                                               params, data)
+                                                self.api_call_part1,
+                                                self.api_call_part2,
+                                                self.api_call_part3,
+                                                identifier1, identifier2,
+                                                params, data)
 
         def patch(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'patch() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'patch() call not available for this endpoint')
 
         def post(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'post() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'post() call not available for this endpoint')
 
         def put(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'put() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'put() call not available for this endpoint')
 
         def delete(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
-	    raise CloudFlareAPIError(0, 'delete() call not available for this endpoint')
+            raise CloudFlareAPIError(0, 'delete() call not available for this endpoint')
 
     class _add_with_auth(object):
         """ Cloudflare v4 API"""
@@ -313,51 +315,51 @@ class CloudFlare(object):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_auth('GET',
-                                            self.api_call_part1,
-                                            self.api_call_part2,
-                                            self.api_call_part3,
-                                            identifier1, identifier2,
-                                            params, data)
+                                             self.api_call_part1,
+                                             self.api_call_part2,
+                                             self.api_call_part3,
+                                             identifier1, identifier2,
+                                             params, data)
 
         def patch(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_auth('PATCH',
-                                            self.api_call_part1,
-                                            self.api_call_part2,
-                                            self.api_call_part3,
-                                            identifier1, identifier2,
-                                            params, data)
+                                             self.api_call_part1,
+                                             self.api_call_part2,
+                                             self.api_call_part3,
+                                             identifier1, identifier2,
+                                             params, data)
 
         def post(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_auth('POST',
-                                            self.api_call_part1,
-                                            self.api_call_part2,
-                                            self.api_call_part3,
-                                            identifier1, identifier2,
-                                            params, data)
+                                             self.api_call_part1,
+                                             self.api_call_part2,
+                                             self.api_call_part3,
+                                             identifier1, identifier2,
+                                             params, data)
 
         def put(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_auth('PUT',
-                                            self.api_call_part1,
-                                            self.api_call_part2,
-                                            self.api_call_part3,
-                                            identifier1, identifier2,
-                                            params, data)
+                                             self.api_call_part1,
+                                             self.api_call_part2,
+                                             self.api_call_part3,
+                                             identifier1, identifier2,
+                                             params, data)
 
         def delete(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_auth('DELETE',
-                                            self.api_call_part1,
-                                            self.api_call_part2,
-                                            self.api_call_part3,
-                                            identifier1, identifier2,
-                                            params, data)
+                                             self.api_call_part1,
+                                             self.api_call_part2,
+                                             self.api_call_part3,
+                                             identifier1, identifier2,
+                                             params, data)
 
     class _add_with_cert_auth(object):
         """ Cloudflare v4 API"""
@@ -374,51 +376,51 @@ class CloudFlare(object):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_certauth('GET',
-                                                self.api_call_part1,
-                                                self.api_call_part2,
-                                                self.api_call_part3,
-                                                identifier1, identifier2,
-                                                params, data)
+                                                 self.api_call_part1,
+                                                 self.api_call_part2,
+                                                 self.api_call_part3,
+                                                 identifier1, identifier2,
+                                                 params, data)
 
         def patch(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_certauth('PATCH',
-                                                self.api_call_part1,
-                                                self.api_call_part2,
-                                                self.api_call_part3,
-                                                identifier1, identifier2,
-                                                params, data)
+                                                 self.api_call_part1,
+                                                 self.api_call_part2,
+                                                 self.api_call_part3,
+                                                 identifier1, identifier2,
+                                                 params, data)
 
         def post(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_certauth('POST',
-                                                self.api_call_part1,
-                                                self.api_call_part2,
-                                                self.api_call_part3,
-                                                identifier1, identifier2,
-                                                params, data)
+                                                 self.api_call_part1,
+                                                 self.api_call_part2,
+                                                 self.api_call_part3,
+                                                 identifier1, identifier2,
+                                                 params, data)
 
         def put(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_certauth('PUT',
-                                                self.api_call_part1,
-                                                self.api_call_part2,
-                                                self.api_call_part3,
-                                                identifier1, identifier2,
-                                                params, data)
+                                                 self.api_call_part1,
+                                                 self.api_call_part2,
+                                                 self.api_call_part3,
+                                                 identifier1, identifier2,
+                                                 params, data)
 
         def delete(self, identifier1=None, identifier2=None, params=None, data=None):
             """ Cloudflare v4 API"""
 
             return self._base.call_with_certauth('DELETE',
-                                                self.api_call_part1,
-                                                self.api_call_part2,
-                                                self.api_call_part3,
-                                                identifier1, identifier2,
-                                                params, data)
+                                                 self.api_call_part1,
+                                                 self.api_call_part2,
+                                                 self.api_call_part3,
+                                                 identifier1, identifier2,
+                                                 params, data)
 
     def __init__(self, email=None, token=None, certtoken=None, debug=False, raw=False):
         """ Cloudflare v4 API"""

--- a/CloudFlare/exceptions.py
+++ b/CloudFlare/exceptions.py
@@ -1,5 +1,6 @@
 """ errors for Cloudflare API"""
 
+
 class CloudFlareError(Exception):
     """ errors for Cloudflare API"""
 
@@ -9,8 +10,10 @@ class CloudFlareError(Exception):
         def __init__(self, code, message):
             self.code = code
             self.message = message
+
         def __int__(self):
             return self.code
+
         def __str__(self):
             return self.message
 
@@ -19,7 +22,8 @@ class CloudFlareError(Exception):
 
         self.e = self._code_message(int(code), str(message))
         self.error_chain = None
-        if error_chain != None:
+
+        if error_chain is not None:
             self.error_chain = []
             for e in error_chain:
                 self.error_chain.append(self._code_message(int(e['code']), str(e['message'])))
@@ -38,7 +42,7 @@ class CloudFlareError(Exception):
     def __len__(self):
         """ Cloudflare API errors can contain a chain of errors"""
 
-        if self.error_chain == None:
+        if self.error_chain is None:
             return 0
         else:
             return len(self.error_chain)
@@ -51,22 +55,23 @@ class CloudFlareError(Exception):
     def __iter__(self):
         """ Cloudflare API errors can contain a chain of errors"""
 
-        if self.error_chain == None:
+        if self.error_chain is None:
             raise StopIteration
         for e in self.error_chain:
             yield e
 
     def next(self):
-        if self.error_chain == None:
+        if self.error_chain is None:
             raise StopIteration()
+
 
 class CloudFlareAPIError(CloudFlareError):
     """ errors for Cloudflare API"""
 
     pass
 
+
 class CloudFlareInternalError(CloudFlareError):
     """ errors for Cloudflare API"""
 
     pass
-

--- a/CloudFlare/logger.py
+++ b/CloudFlare/logger.py
@@ -1,8 +1,12 @@
 """ Logging for Cloudflare API"""
+
+from __future__ import absolute_import
+
 import logging
 
 DEBUG = 0
 INFO = 1
+
 
 class Logger(object):
     """ Logging for Cloudflare API"""

--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -1,8 +1,15 @@
 """ reading the config file for Cloudflare API"""
 
+from __future__ import absolute_import
+
 import os
 import re
-import ConfigParser
+
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
+
 
 def read_configs():
     """ reading the config file for Cloudflare API"""

--- a/CloudFlare/utils.py
+++ b/CloudFlare/utils.py
@@ -1,5 +1,6 @@
 """ misc utilities  for Cloudflare API"""
 
+
 def sanitize_secrets(secrets):
     """ misc utilities  for Cloudflare API"""
     redacted_phrase = 'REDACTED'

--- a/cli4/__main__.py
+++ b/cli4/__main__.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 """Cloudflare API via command line"""
 
+from __future__ import absolute_import
+
 import sys
 
-from cli4 import cli4
+from .cli4 import cli4
+
 
 def main(args=None):
     """Cloudflare API via command line"""
@@ -11,6 +14,6 @@ def main(args=None):
         args = sys.argv[1:]
     cli4(args)
 
+
 if __name__ == '__main__':
     main()
-

--- a/cli4/cli4.py
+++ b/cli4/cli4.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
 """Cloudflare API via command line"""
 
-import os
-import sys
-import re
+from __future__ import absolute_import
+
 import getopt
 import json
+import os
+import re
+import sys
+
 try:
     import yaml
 except ImportError:
     yaml = None
 
 sys.path.insert(0, os.path.abspath('..'))
-import CloudFlare
-import CloudFlare.exceptions
+
+import CloudFlare  # noqa
+import CloudFlare.exceptions  # noqa
+
 
 def convert_zones_to_identifier(cf, zone_name):
     """zone names to numbers"""
-    params = {'name':zone_name, 'per_page':1}
+    params = {'name': zone_name, 'per_page': 1}
     try:
         zones = cf.zones.get(params=params)
     except CloudFlare.exceptions.CloudFlareAPIError as e:
@@ -31,10 +36,11 @@ def convert_zones_to_identifier(cf, zone_name):
 
     exit('cli4: %s - zone not found' % (zone_name))
 
+
 def convert_dns_record_to_identifier(cf, zone_id, dns_name):
     """dns record names to numbers"""
     # this can return an array of results as there can be more than one DNS entry for a name.
-    params = {'name':dns_name}
+    params = {'name': dns_name}
     try:
         dns_records = cf.zones.dns_records.get(zone_id, params=params)
     except CloudFlare.exceptions.CloudFlareAPIError as e:
@@ -51,6 +57,7 @@ def convert_dns_record_to_identifier(cf, zone_id, dns_name):
 
     exit('cli4: %s - dns name not found' % (dns_name))
 
+
 def convert_certificates_to_identifier(cf, certificate_name):
     """certificate names to numbers"""
     try:
@@ -65,6 +72,7 @@ def convert_certificates_to_identifier(cf, certificate_name):
             return certificate['id']
 
     exit('cli4: %s - no zone certificates found' % (certificate_name))
+
 
 def convert_organizations_to_identifier(cf, organization_name):
     """organizations names to numbers"""
@@ -81,6 +89,7 @@ def convert_organizations_to_identifier(cf, organization_name):
 
     exit('cli4: %s - no organizations found' % (organization_name))
 
+
 def convert_invites_to_identifier(cf, invite_name):
     """invite names to numbers"""
     try:
@@ -96,6 +105,7 @@ def convert_invites_to_identifier(cf, invite_name):
 
     exit('cli4: %s - no invites found' % (invite_name))
 
+
 def convert_virtual_dns_to_identifier(cf, virtual_dns_name):
     """virtual dns names to numbers"""
     try:
@@ -110,6 +120,7 @@ def convert_virtual_dns_to_identifier(cf, virtual_dns_name):
             return virtual_dns['id']
 
     exit('cli4: %s - no virtual_dns found' % (virtual_dns_name))
+
 
 def walk(m, s):
     """recursive walk of the tree"""
@@ -129,9 +140,11 @@ def walk(m, s):
                 print(s + '/' + n)
             walk(a, s + '/' + n)
 
+
 def dump_commands(cf):
     """dump a tree of all the known API commands"""
     walk(cf, '')
+
 
 def cli4(args):
     """Cloudflare API via command line"""
@@ -205,7 +218,7 @@ def cli4(args):
         elif value_string[0] in '[{' and value_string[-1] in '}]':
             # a json structure - used in pagerules
             try:
-                #value = json.loads(value) - changed to yaml code to remove unicode string issues
+                # value = json.loads(value) - changed to yaml code to remove unicode string issues
                 if yaml is None:
                     exit('cli4: install yaml support')
                 value = yaml.safe_load(value_string)
@@ -329,4 +342,3 @@ def cli4(args):
         print(json.dumps(results, indent=4, sort_keys=True))
     if output == 'yaml' and yaml is not None:
         print(yaml.safe_dump(results))
-


### PR DESCRIPTION
Now using `absolute_import` from [`__future__`](https://docs.python.org/2/library/__future__.html) to mimic Python 3 behaviour: this is needed for relative imports ([PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-relative-imports)).

Without this changes the package fails when using it with Python 3.\* because the `__init__` file raises an Exception when trying to:

``` python
from cloudflare import CloudFlare
```

In the process I have fixed some indentation problems with mixed tabs and spaces.
