### PR TITLE
Update Load Balancing endpoints to reflect latest API changes

### DIFF
--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -313,19 +313,9 @@ def user_load_balancers(self):
     setattr(branch, "load_balancers",
             self._add_unused(base, "user/load_balancers"))
     branch = getattr(getattr(self, "user"), "load_balancers")
-    setattr(branch, "global_policies",
-            self._add_with_auth(base, "user/load_balancers/global_policies"))
     setattr(branch, "monitors",
             self._add_with_auth(base, "user/load_balancers/monitors"))
-    setattr(branch, "notifiers",
-            self._add_with_auth(base, "user/load_balancers/notifiers"))
-    setattr(branch, "origins",
-            self._add_with_auth(base, "user/load_balancers/origins"))
     setattr(branch, "pools",
             self._add_with_auth(base, "user/load_balancers/pools"))
-    setattr(branch, "maps",
-            self._add_with_auth(base, "user/load_balancers/maps"))
-    branch = getattr(getattr(getattr(self, "user"), "load_balancers"), "maps")
-    setattr(branch, "region",
-            self._add_with_auth(base, "user/load_balancers/maps", "region"))
+    branch = getattr(getattr(getattr(self, "user"), "load_balancers"), "pools")
 

--- a/cli4/cli4.py
+++ b/cli4/cli4.py
@@ -111,42 +111,20 @@ def convert_virtual_dns_to_identifier(cf, virtual_dns_name):
 
     exit('cli4: %s - no virtual_dns found' % (virtual_dns_name))
 
-def convert_load_balancers_map_to_identifier(cf, map_name):
-    """load balancer map names to numbers"""
+def convert_load_balancers_pool_to_identifier(cf, pool_name):
+    """load balancer pool names to numbers"""
     try:
-        maps = cf.user.load_balancers.maps.get()
+        pools = cf.user.load_balancers.pools.get()
     except CloudFlare.exceptions.CloudFlareAPIError as e:
-        exit('cli4: %s - %d %s' % (map_name, e, e))
+        exit('cli4: %s - %d %s' % (pool_name, e, e))
     except Exception as e:
-        exit('cli4: %s - %s' % (map_name, e))
+        exit('cli4: %s - %s' % (pool_name, e))
 
-    for m in maps:
-        if map_name == m['description']:
-            return m['id']
+    for p in pools:
+        if pool_name == p['description']:
+            return p['id']
 
-    exit('cli4: %s - no maps found' % (map_name))
-
-def convert_load_balancers_map_regions(cf, region_name):
-    """load balancer map regions"""
-    # this will/must go away; however it allows :WNAM etc in path.
-    regions = {
-        'WNAM',	# Western North America
-        'ENAM',	# Eastern North America
-        'EU',	# Europe
-        'NSAM',	# Northern South America
-        'SSAM',	# Southern South America
-        'OC',	# Oceania
-        'ME',	# Middle East
-        'NAF',	# Northern Africa
-        'SAF',	# Southern Africa
-        'IN',	# India
-        'SEAS',	# Southeast Asia
-        'NEAS',	# Northeast Asia
-        'CHINA'	# China
-    }
-    if region_name in regions:
-        return region_name
-    exit('cli4: %s - no region found' % (region_name))
+    exit('cli4: %s - no pools found' % (pool_name))
 
 def dump_commands(cf):
     """dump a tree of all the known API commands"""
@@ -313,8 +291,8 @@ def cli4(args):
                     identifier1 = convert_invites_to_identifier(cf, element)
                 elif (cmd[0] == 'user') and (cmd[1] == 'virtual_dns'):
                     identifier1 = convert_virtual_dns_to_identifier(cf, element)
-                elif (cmd[0] == 'user') and (cmd[1] == 'load_balancers') and (cmd[2] == 'maps'):
-                    identifier1 = convert_load_balancers_map_to_identifier(cf, element)
+                elif (cmd[0] == 'user') and (cmd[1] == 'load_balancers') and (cmd[2] == 'pools'):
+                    identifier1 = convert_load_balancers_pool_to_identifier(cf, element)
                 else:
                     exit("/%s/%s :NOT CODED YET 1" % ('/'.join(cmd), element))
                 cmd.append(':' + identifier1)
@@ -324,11 +302,6 @@ def cli4(args):
                     identifier2 = element
                 elif (cmd[0] and cmd[0] == 'zones') and (cmd[2] and cmd[2] == 'dns_records'):
                     identifier2 = convert_dns_record_to_identifier(cf, identifier1, element)
-                elif ((cmd[0] == 'user') and
-                      (cmd[1] == 'load_balancers') and
-                      (cmd[2] == 'maps') and
-                      (cmd[4] == 'region')):
-                    identifier2 = convert_load_balancers_map_regions(cf, element)
                 else:
                     exit("/%s/%s :NOT CODED YET 2" % ('/'.join(cmd), element))
                 # identifier2 may be an array - this needs to be dealt with later


### PR DESCRIPTION
No more global_pools, origins, notifiers, or maps. Latest API version [here](https://www.cloudflare.com/docs/load-balancing-api-reference-20161220.html). 

* We've simplified our configuration API! There are now only *three* endpoints:
    * The "load_balancers" API endpoint on your zone(s) now combines the 'old' Load Balancer, Global Policy and Map into a single configuration.
    * The "pools" API endpoint combines the 'old' Pool, Origin and Notifier into a single configuration.
    * The "monitors" API endpoint is unchanged: how we monitor your infrastructure is important, and thus we wanted to retain the ability for our customers to update a Monitor (increase the timeout, change the status code, etc.) and have it be immediately reflected wherever it is in-use.