### PR TITLE
http2 / pseudo ipv4 settings

### DIFF
--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -171,6 +171,10 @@ def zones_settings(self):
             self._add_with_auth(base, "zones", "settings/websockets"))
     setattr(branch, "waf",
             self._add_with_auth(base, "zones", "settings/waf"))
+    setattr(zones_settings, "http2",
+            self._add_with_auth(self._base, "zones", "settings/http2"))
+    setattr(zones_settings, "pseudo_ipv4",
+            self._add_with_auth(self._base, "zones", "settings/pseudo_ipv4"))
 
 def zones_analytics(self):
     """ API core commands for Cloudflare API"""

--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -171,9 +171,9 @@ def zones_settings(self):
             self._add_with_auth(base, "zones", "settings/websockets"))
     setattr(branch, "waf",
             self._add_with_auth(base, "zones", "settings/waf"))
-    setattr(zones_settings, "http2",
+    setattr(branch, "http2",
             self._add_with_auth(base, "zones", "settings/http2"))
-    setattr(zones_settings, "pseudo_ipv4",
+    setattr(branch, "pseudo_ipv4",
             self._add_with_auth(base, "zones", "settings/pseudo_ipv4"))
 
 def zones_analytics(self):

--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -172,9 +172,9 @@ def zones_settings(self):
     setattr(branch, "waf",
             self._add_with_auth(base, "zones", "settings/waf"))
     setattr(zones_settings, "http2",
-            self._add_with_auth(self._base, "zones", "settings/http2"))
+            self._add_with_auth(base, "zones", "settings/http2"))
     setattr(zones_settings, "pseudo_ipv4",
-            self._add_with_auth(self._base, "zones", "settings/pseudo_ipv4"))
+            self._add_with_auth(base, "zones", "settings/pseudo_ipv4"))
 
 def zones_analytics(self):
     """ API core commands for Cloudflare API"""


### PR DESCRIPTION
added missing settings
cli4 --patch value=on /zones/:identifier/settings/http2
cli4 --patch value=overwrite_header /zones/:identifier/settings/pseudo_ipv4

@mahtin could you add it please?