### PR TITLE
Refactor imports

### DIFF
--- a/CloudFlare/__init__.py
+++ b/CloudFlare/__init__.py
@@ -1,8 +1,8 @@
 """ Cloudflare v4 API"""
-
-try:
-    from cloudflare import CloudFlare
-except:
-    pass
+from __future__ import absolute_import
 
 __version__ = '1.4.11'
+
+from .cloudflare import CloudFlare
+
+__all__ = ['CloudFlare']

--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -1,15 +1,15 @@
 """ Cloudflare v4 API"""
+from __future__ import absolute_import
 
 import json
-import urllib
 import requests
 
-from logger import Logger
-from utils import user_agent, sanitize_secrets
-from read_configs import read_configs
-from api_v4 import api_v4
-from api_extras import api_extras
-from exceptions import CloudFlareError, CloudFlareAPIError, CloudFlareInternalError
+from .logger import Logger
+from .utils import user_agent, sanitize_secrets
+from .read_configs import read_configs
+from .api_v4 import api_v4
+from .api_extras import api_extras
+from .exceptions import CloudFlareError, CloudFlareAPIError, CloudFlareInternalError
 
 BASE_URL = 'https://api.cloudflare.com/client/v4'
 

--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -2,7 +2,10 @@
 
 import os
 import re
-import ConfigParser
+try:
+    import ConfigParser  # py2
+except ImportError:
+    import configparser as ConfigParser  # py3
 
 def read_configs():
     """ reading the config file for Cloudflare API"""

--- a/CloudFlare/utils.py
+++ b/CloudFlare/utils.py
@@ -1,8 +1,10 @@
 """ misc utilities  for Cloudflare API"""
+from __future__ import absolute_import
 
 import sys
 import requests
-from __init__ import __version__
+
+from . import __version__
 
 def user_agent():
     """ misc utilities  for Cloudflare API"""

--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ The exception returns both an integer and textual message in one value.
 
 ```python
 import CloudFlare
-import CloudFlare.exceptions
 
     ...
     try
@@ -316,7 +315,6 @@ You can itterate over that array to see the additional error.
 ```python
 import sys
 import CloudFlare
-import CloudFlare.exceptions
 
     ...
     try

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,6 @@ A more complex example follows.
 .. code:: python
 
     import CloudFlare
-    import CloudFlare.exceptions
 
     def main():
         zone_name = 'example.com'
@@ -336,7 +335,6 @@ The exception returns both an integer and textual message in one value.
 .. code:: python
 
     import CloudFlare
-    import CloudFlare.exceptions
 
         ...
         try
@@ -356,7 +354,6 @@ the additional error.
 
     import sys
     import CloudFlare
-    import CloudFlare.exceptions
 
         ...
         try

--- a/cli4/__main__.py
+++ b/cli4/__main__.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 """Cloudflare API via command line"""
+from __future__ import absolute_import
 
 import sys
 
-from cli4 import cli4
+from .cli4 import cli4
 
 def main(args=None):
     """Cloudflare API via command line"""

--- a/cli4/cli4.py
+++ b/cli4/cli4.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Cloudflare API via command line"""
 
-import os
 import sys
 import re
 import getopt
@@ -11,11 +10,9 @@ try:
 except ImportError:
     yaml = None
 
-import converters
+from . import converters
 
-sys.path.insert(0, os.path.abspath('..'))
 import CloudFlare
-import CloudFlare.exceptions
 
 def dump_commands(cf):
     """dump a tree of all the known API commands"""

--- a/cli4/converters.py
+++ b/cli4/converters.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python
 """Cloudflare API via command line"""
+from __future__ import absolute_import
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath('..'))
 import CloudFlare
-import CloudFlare.exceptions
 
 def convert_zones_to_identifier(cf, zone_name):
     """zone names to numbers"""

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 """Cloudflare API code - setup.py file"""
-
+import re
 from setuptools import setup, find_packages
-from CloudFlare import __version__
+
+_version_re = re.compile(r"__version__\s=\s'(.*)'")
+
 
 def main():
     """Cloudflare API code - setup.py file"""
@@ -10,9 +12,12 @@ def main():
     with open('README.rst') as read_me:
         long_description = read_me.read()
 
+    with open('CloudFlare/__init__.py', 'r') as f:
+        version = _version_re.search(f.read()).group(1)
+
     setup(
         name='cloudflare',
-        version=__version__,
+        version=version,
         description='Python wrapper for the Cloudflare v4 API',
         long_description=long_description,
         author='Martin J. Levy',
@@ -50,6 +55,7 @@ def main():
             'Programming Language :: Python :: 3.6'
         ]
     )
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is a refactor of the imports in the CloudFlare library. I was prompted to make these changes when trying to use the cli4 utility with Python 3.5 and it wouldn't run. I have done a quick test with the changes on Python 2.6, 2.7. 3.3, 3.4 and 3.5.

**Improved compatibility**
- Uses absolute imports for Python 3 compatibility.
- ConfigParser has changed name and will now be imported correctly on Python 3. This error was hidden by the \_\_init\_\_.py try-except block.

**Robustness and clear errors**
- Removed the try-except block from \_\_init\_\_.py. This was added in commit 110870b4524cad34f7ddd780d9532f5b3e09d374 on the basis that "python3 does not need the import statement", which I cannot reproduce. If this import statement is removed then cli4 will not work with Python 3. Because this block allows real errors to pass silently that would have made it imminently more clear what's wrong it has been removed and the hidden errors fixed.
- Moved \_\_version\_\_ to the top of \_\_init\_\_.py (before the class import). This must be done because the import of CloudFlare module from the cli4 utility or other scripts will in turn import utility.py which attempts to import \_\_version\_\_, but \_\_version\_\_ has not been set up at that point so the import will fail due to this layout. This error was hidden by the \_\_init\_\_.py try-except block.
- Removes import of CloudFlare from setup.py. The import of the library before installation will fail on systems that do not already have all the dependencies that the setup is meant to install already, thereby failing the entire installation. Instead extract the version number with a regex, treating the \_\_init\_\_.py file just as text rather than code, that way there is still just one location for the version number. This is the root cause of #9.

**Cleaning up**
- Removes some unused stdlib imports (urllib, os, sys).
- Removes superfluous import of CloudFlare.exceptions. No use since the top module CloudFlare is always imported in these cases.
- Removes "#!/usr/bin/env python" from non-script file converters.py.
- Removes usage of sys.path.insert(0, os.path.abspath('..')). No need for this workaround when absolute imports are used.

**Documentation and discoverability**
- Only import CloudFlare, not CloudFlare.exceptions (same as the code change).
- Adds the CloudFlare class to the \_\_all\_\_ variable in \_\_init\_\_.py. This will produce useful output when issuing "import CloudFlare; help(CloudFlare)".

**Not done (and don't intend to)**
I have not changed the test or the examples.