### PR TITLE
Fix Pagination in example raw code

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ def main():
     cf = CloudFlare.CloudFlare(raw=True)
     page_number = 0
     while True:
+    	page_number += 1
         raw_results = cf.zones.get(params={'per_page':5,'page':page_number})
         zones = raw_results['result']
 
@@ -112,7 +113,6 @@ def main():
             print zone_id, zone_name
 
         total_pages = raw_results['result_info']['total_pages']
-        page_number += 1
         if page_number == total_pages:
             break
 


### PR DESCRIPTION
Page 0 is the same as page 1. And the way that the page is incremented just before the check to see if you are at the final page causes the loop to exit early. By incrementing at the beginning of the loop you get all pages of data and don't miss the last page.