### PR TITLE
README: Fix typo of kwarg "params" in sample code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ import CloudFlare
 def main():
     zone_name = sys.argv[1]
     cf = CloudFlare.CloudFlare()
-    zone_info = cf.zones.get(param={'name': zone_name})
+    zone_info = cf.zones.get(params={'name': zone_name})
     zone_id = zone_info['id']
 
     dns_name = sys.argv[2]

--- a/README.rst
+++ b/README.rst
@@ -458,7 +458,7 @@ A DNS zone delete code example (be careful)
     def main():
         zone_name = sys.argv[1]
         cf = CloudFlare.CloudFlare()
-        zone_info = cf.zones.get(param={'name': zone_name})
+        zone_info = cf.zones.get(params={'name': zone_name})
         zone_id = zone_info['id']
 
         dns_name = sys.argv[2]


### PR DESCRIPTION
The kwarg is actually named `params` but incorrectly written as `param` in the code snippets in the README files.