### PR TITLE
Remove logger from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.4.2
-logger
 future
 pyyaml
 jsonlines


### PR DESCRIPTION
It was removed from `setup.py` in 16129a394cdc43e07e67cea9b6c14358311f66f4.