### PR TITLE
DNS-3431: Support Secondary DNS Endpoints

### DIFF
--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -45,6 +45,7 @@ def api_v4(self):
     # The API commands for /account/
     account(self)
     account_load_balancing_analytics(self)
+    account_secondary_dns(self)
 
 def user(self):
     """ API core commands for Cloudflare API"""
@@ -82,6 +83,7 @@ def zones(self):
     self.add('AUTH', "zones", "purge_cache")
     self.add('AUTH', "zones", "railguns")
     self.add('AUTH', "zones", "railguns", "diagnose")
+    self.add('AUTH', "zones", "secondary_dns")
     self.add('AUTH', "zones", "subscription")
     self.add('AUTH', "zones", "subscriptions")
 
@@ -306,6 +308,13 @@ def account_load_balancing_analytics(self):
     self.add('VOID', "account", "load_balancing_analytics")
     self.add('AUTH', "account", "load_balancing_analytics/events")
     self.add('AUTH', "account", "load_balancing_analytics/entities")
+
+def account_secondary_dns(self):
+    """ API core commands for Cloudflare API"""
+
+    self.add('VOID', "account", "secondary_dns")
+    self.add('AUTH', "account", "secondary_dns/masters")
+    self.add('AUTH', "account", "secondary_dns/tsigs")
 
 def zones_media(self):
     """ API core commands for Cloudflare API"""


### PR DESCRIPTION
### Overview

This PR adds support for Secondary DNS Endpoints, and allows users to manage Secondary Cloudflare. e.g:

```python
#!/usr/bin/env python

import sys
import CloudFlare

def main():
    zone_name = sys.argv[1]
    cf = CloudFlare.CloudFlare()
    zone_info = cf.zones.post(data={'jump_start':False, 'name': zone_name})
    zone_id = zone_info['id']

   
    r = cf.zones.secondary_dns.post(zone_id, data={
        "id" : "269d8f4853475ca241c4e730be286b20",
        "name" : "www.example.com.",
        "masters" :
        [
            "23ff594956f20c2a721606e94745a8aa",
            "00920f38ce07c2e2f4df50b1f61d4194"
        ],
        "auto_refresh_seconds" : 30
    })
    exit(0)

if __name__ == '__main__':
    main()
```