### PR TITLE
Fix python syntax to suppress 3.8 warnings about "is with a literal"

### DIFF
--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -836,11 +836,11 @@ class CloudFlare(object):
         if certtoken is None:
             certtoken = conf_certtoken
 
-        if email is '':
+        if email == '':
             email = None
-        if token is '':
+        if token == '':
             token = None
-        if certtoken is '':
+        if certtoken == '':
             certtoken = None
         self._base = self._v4base(email, token, certtoken, base_url, debug, raw, use_sessions)
 


### PR DESCRIPTION
Python 3.8 is now displaying a warning when `is` is used with a literal.

Here are the relevant errors with 2.4.0:
```
/usr/lib/python3.8/site-packages/CloudFlare/cloudflare.py:839: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if email is '':
/usr/lib/python3.8/site-packages/CloudFlare/cloudflare.py:841: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if token is '':
/usr/lib/python3.8/site-packages/CloudFlare/cloudflare.py:843: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if certtoken is '':
```

See https://github.com/python/cpython/pull/9642 for more info

closes #83 