### PR TITLE
Update information regarding default Zone list value from 50 to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     main()
 ```
 
-This example works when there are less than 50 zones (50 is the default number of values returned from a query like this).
+This example works when there are less than 21 zones (20 is the default number of values returned from a query like this).
 
 Now lets expand on that and add code to show the IPv6 and SSL status of the zones. Lets also query 100 zones.
 


### PR DESCRIPTION
Hi,

It seems that the default limit for this call is the limit of the first page listing which is  20 , on the bellow, evidences bellow. Its important to consider that we are bypassing one free domain under our account, so in that case, would be 19 enterprise domains + 1 free 

Total Zones:
![image](https://user-images.githubusercontent.com/31625914/90217242-bd8d3f80-ddf8-11ea-8fb2-21dd39a5e68c.png)


Api Call result from get started:
![image](https://user-images.githubusercontent.com/31625914/90217166-7737e080-ddf8-11ea-884c-cdcbbfb2b1ab.png)


Specifying limit per page:

![image](https://user-images.githubusercontent.com/31625914/90217360-0d6c0680-ddf9-11ea-9100-9f535c3b9960.png)