### PR TITLE
Use Python3 print() syntax instead of Python2 print in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def main():
     for zone in zones:
         zone_id = zone['id']
         zone_name = zone['name']
-        print zone_id, zone_name
+        print(zone_id, zone_name)
 
 if __name__ == '__main__':
     main()
@@ -85,7 +85,7 @@ def main():
         settings_ipv6 = cf.zones.settings.ipv6.get(zone_id)
         ipv6_status = settings_ipv6['value']
 
-        print zone_id, zone_name, ssl_status, ipv6_status
+        print(zone_id, zone_name, ssl_status, ipv6_status)
 
 if __name__ == '__main__':
     main()
@@ -110,7 +110,7 @@ def main():
         for zone in zones:
             zone_id = zone['id']
             zone_name = zone['name']
-            print zone_id, zone_name
+            print(zone_id, zone_name)
 
         total_pages = raw_results['result_info']['total_pages']
         if page_number == total_pages:
@@ -152,7 +152,7 @@ def main():
         exit('/zones/dns_records.get %d %s - api call failed' % (e, e))
 
     # print the results - first the zone name
-    print zone_id, zone_name
+    print(zone_id, zone_name)
 
     # then all the DNS records for that zone
     for dns_record in dns_records:
@@ -160,7 +160,7 @@ def main():
         r_type = dns_record['type']
         r_value = dns_record['content']
         r_id = dns_record['id']
-        print '\t', r_id, r_name, r_type, r_value
+        print('\t', r_id, r_name, r_type, r_value)
 
     exit(0)
 
@@ -322,7 +322,7 @@ import CloudFlare
 def main():
     cf = CloudFlare.CloudFlare()
     zones = cf.zones.get(params={'per_page':5})
-    print len(zones)
+    print(len(zones))
 
 if __name__ == '__main__':
     main()
@@ -345,8 +345,9 @@ import CloudFlare
 def main():
     cf = CloudFlare.CloudFlare(raw=True)
     zones = cf.zones.get(params={'per_page':5})
-    print zones.length()
-    print json.dumps(zones, indent=4, sort_keys=True)
+    
+    zones.length()
+    print(json.dumps(zones, indent=4, sort_keys=True))
 
 if __name__ == '__main__':
     main()
@@ -908,7 +909,7 @@ def main():
     for l in dns_records.splitlines():
         if len(l) == 0 or l[0] == ';':
             continue
-        print l
+        print(l)
     exit(0)
 
 if __name__ == '__main__':

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ def main():
     cf = CloudFlare.CloudFlare(raw=True)
     zones = cf.zones.get(params={'per_page':5})
     
-    zones.length()
+    print(zones.length())
     print(json.dumps(zones, indent=4, sort_keys=True))
 
 if __name__ == '__main__':

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ status of the zone.
         for zone in zones:
             zone_id = zone['id']
             zone_name = zone['name']
-            print zone_id, zone_name
+            print(zone_id, zone_name)
 
     if __name__ == '__main__':
         main()
@@ -106,7 +106,7 @@ the zones. Lets also query 100 zones.
             settings_ipv6 = cf.zones.settings.ipv6.get(zone_id)
             ipv6_status = settings_ipv6['value']
 
-            print zone_id, zone_name, ssl_status, ipv6_status
+            print(zone_id, zone_name, ssl_status, ipv6_status)
 
     if __name__ == '__main__':
         main()
@@ -133,7 +133,7 @@ returning many items.
             for zone in zones:
                 zone_id = zone['id']
                 zone_name = zone['name']
-                print zone_id, zone_name
+                print(zone_id, zone_name)
 
             total_pages = raw_results['result_info']['total_pages']
             if page_number == total_pages:
@@ -175,7 +175,7 @@ A more complex example follows.
             exit('/zones/dns_records.get %d %s - api call failed' % (e, e))
 
         # print the results - first the zone name
-        print zone_id, zone_name
+        print(zone_id, zone_name)
 
         # then all the DNS records for that zone
         for dns_record in dns_records:
@@ -183,7 +183,7 @@ A more complex example follows.
             r_type = dns_record['type']
             r_value = dns_record['content']
             r_id = dns_record['id']
-            print '\t', r_id, r_name, r_type, r_value
+            print('\t', r_id, r_name, r_type, r_value)
 
         exit(0)
 
@@ -370,7 +370,7 @@ Here's an example without paging.
     def main():
         cf = CloudFlare.CloudFlare()
         zones = cf.zones.get(params={'per_page':5})
-        print len(zones)
+        print(len(zones))
 
     if __name__ == '__main__':
         main()
@@ -394,8 +394,8 @@ means the paging values can be seen.
     def main():
         cf = CloudFlare.CloudFlare(raw=True)
         zones = cf.zones.get(params={'per_page':5})
-        print zones.length()
-        print json.dumps(zones, indent=4, sort_keys=True)
+        print(zones.length())
+        print(json.dumps(zones, indent=4, sort_keys=True))
 
     if __name__ == '__main__':
         main()
@@ -1005,7 +1005,7 @@ This can also be done via Python code with the following example.
         for l in dns_records.splitlines():
             if len(l) == 0 or l[0] == ';':
                 continue
-            print l
+            print(l)
         exit(0)
 
     if __name__ == '__main__':


### PR DESCRIPTION
README.md and README.rst still use the old Python2
```
print "x"
```
syntax which causes error when copy & pasting the code into Python3.

This PR changes the print syntax in README to use
```
print("x")
```
Note that this syntax is fully compatible with recent versions of Python2 as well as all versions of Python3.