### PR TITLE
typo in cloudflare.py when handeling props with dashes (email-fwdr)

### DIFF
--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -826,7 +826,7 @@ class CloudFlare(object):
         for element in a[0:-1]:
             try:
                 if '-' in element:
-                    branch = getattr(element, element.replace('-','_'))
+                    branch = getattr(branch, element.replace('-','_'))
                 else:
                     branch = getattr(branch, element)
             except:


### PR DESCRIPTION
fixed ability to add email-fwdr (there's a type preventing the dash to be properly converted)

here's my code if anyone wants to add an email request validation:

```python
    cf = CloudFlare(email=CLOUDFLARE_EMAIL, token=CLOUDFLARE_TOKEN)
    cf.add('VOID', "accounts", "email-fwdr")
    cf.add('AUTH', "accounts", "email-fwdr", "addresses")
    data = json.dumps({"email": email})
    cf.accounts.email_fwdr.addresses.post(CLOUDFLARE_ACCOUNT, data=data)
```