### PR TITLE
Added Bot Management ability and fixed an edge case for the API return

### DIFF
--- a/CloudFlare/api_v4.py
+++ b/CloudFlare/api_v4.py
@@ -83,6 +83,7 @@ def zones(self):
     self.add('AUTH', "zones", "activation_check")
     self.add('AUTH', "zones", "available_plans")
     self.add('AUTH', "zones", "available_rate_plans")
+    self.add('AUTH', "zones", "bot_management")
     self.add('AUTH', "zones", "custom_certificates")
     self.add('AUTH', "zones", "custom_certificates/prioritize")
     self.add('AUTH', "zones", "custom_hostnames")

--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -470,7 +470,7 @@ class CloudFlare(object):
                         response_data['success'] = True
 
             if response_data['success'] is False:
-                if 'errors' in response_data:
+                if 'errors' in response_data and response_data['errors'] != None:
                     errors = response_data['errors'][0]
                 else:
                     errors = {}

--- a/examples/example_page_rules.py
+++ b/examples/example_page_rules.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Cloudflare API code - example"""
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+import CloudFlare
+
+def main():
+    """Cloudflare API code - example"""
+
+    try:
+        zone_name = sys.argv[1]
+    except IndexError:
+        exit('usage: example_page_rules.py zone')
+
+    cf = CloudFlare.CloudFlare()
+
+    # grab the zone identifier
+    try:
+        params = {'name': zone_name}
+        zones = cf.zones.get(params=params)
+    except CloudFlare.exceptions.CloudFlareAPIError as e:
+        exit('/zones %d %s - api call failed' % (e, e))
+    except Exception as e:
+        exit('/zones.get - %s - api call failed' % (e))
+
+    if len(zones) == 0:
+        exit('/zones.get - %s - zone not found' % (zone_name))
+
+    if len(zones) != 1:
+        exit('/zones.get - %s - api call returned %d items' % (zone_name, len(zones)))
+
+    zone_id = zones[0]['id']
+
+    url_match=f"*.{zone_name}/url1*"
+    url_forwarded=f"http://{zone_name}/url2"
+
+    targets=[{"target":"url","constraint":{"operator":"matches","value":url_match}}]
+    actions=[{"id":"forwarding_url","value":{"status_code":302,"url":url_forwarded}}]
+    pagerule_for_redirection = {"status": "active","priority": 1,"actions": actions,"targets": targets}
+
+    try:
+        r = cf.zones.pagerules.get(zone_id, data=pagerule_for_redirection)
+    except CloudFlare.exceptions.CloudFlareAPIError as e:
+        exit('/zones.pagerules.get %d %s - api call failed' % (e, e))
+
+    create=True
+
+    for rule in r:
+        if (rule['actions'] == pagerule_for_redirection["actions"] and rule["targets"] == pagerule_for_redirection["targets"]):
+            print('\t', '... rule already present!')
+            create=False
+            break
+
+    if (create):
+        try:
+            r = cf.zones.pagerules.post(zone_id, data=pagerule_for_redirection)
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
+            exit('/zones.pagerules.post %d %s - api call failed' % (e, e))
+        if (r['actions'] == pagerule_for_redirection["actions"] and r["targets"] == pagerule_for_redirection["targets"]):
+            print('\t', '... created!')
+    exit(0)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
The 'Bot Management' API is an undocumented API, but one that can still be called through the use of an API key. 

Weirdly, this API returns a 'null' for errors when success is False - which suggests it may not be completely finished. Either way, adding a check in for NoneTypes on the error case is probably proper (considering it was done above when success is not present - although this assumes success afterwards).