### PR TITLE
update environment variables to be prefixed with `CLOUDFLARE_`

### DIFF
--- a/CloudFlare/read_configs.py
+++ b/CloudFlare/read_configs.py
@@ -14,11 +14,11 @@ def read_configs(profile=None):
     config = {'email': None, 'token': None, 'certtoken': None, 'extras': None, 'base_url': None, 'profile': None}
 
     # envioronment variables override config files - so setup first
-    config['email'] = os.getenv('CF_API_EMAIL')
-    config['token'] = os.getenv('CF_API_KEY')
-    config['certtoken'] = os.getenv('CF_API_CERTKEY')
-    config['extras'] = os.getenv('CF_API_EXTRAS')
-    config['base_url'] = os.getenv('CF_API_URL')
+    config['email'] = os.getenv('CLOUDFLARE_EMAIL') if os.getenv('CLOUDFLARE_EMAIL') != None else os.getenv('CF_API_EMAIL')
+    config['token'] = os.getenv('CLOUDFLARE_API_KEY') if os.getenv('CLOUDFLARE_API_KEY') != None else os.getenv('CF_API_KEY')
+    config['certtoken'] = os.getenv('CLOUDFLARE_API_CERTKEY') if os.getenv('CLOUDFLARE_API_CERTKEY') != None else  os.getenv('CF_API_CERTKEY')
+    config['extras'] = os.getenv('CLOUDFLARE_API_EXTRAS') if os.getenv('CLOUDFLARE_API_EXTRAS') != None os.getenv('CF_API_EXTRAS')
+    config['base_url'] = os.getenv('CLOUDFLARE_API_URL') if os.getenv('CLOUDFLARE_API_URL') != None os.getenv('CF_API_URL')
     if profile is None:
         profile = 'CloudFlare'
     config['profile'] = profile

--- a/README.md
+++ b/README.md
@@ -202,16 +202,16 @@ import CloudFlare
 
 If the account email and API key are not passed when you create the class, then they are retrieved from either the users exported shell environment variables or the .cloudflare.cfg or ~/.cloudflare.cfg or ~/.cloudflare/cloudflare.cfg files, in that order.
 
-If you're using an API Token, any `cloudflare.cfg` file must either not contain an `email` attribute or be a zero length string and the `CF_API_EMAIL` environment variable must be unset or be a zero length string, otherwise the token will be treated as a key and will throw an error.
+If you're using an API Token, any `cloudflare.cfg` file must either not contain an `email` attribute or be a zero length string and the `CLOUDFLARE_EMAIL` environment variable must be unset or be a zero length string, otherwise the token will be treated as a key and will throw an error.
 
 There is one call that presently doesn't need any email or token certification (the */ips* call); hence you can test without any values saved away.
 
 ### Using shell environment variables
 
 ```bash
-$ export CF_API_EMAIL='user@example.com' # Do not set if using an API Token
-$ export CF_API_KEY='00000000000000000000000000000000'
-$ export CF_API_CERTKEY='v1.0-...'
+$ export CLOUDFLARE_EMAIL='user@example.com' # Do not set if using an API Token
+$ export CLOUDFLARE_API_KEY='00000000000000000000000000000000'
+$ export CLOUDFLARE_API_CERTKEY='v1.0-...'
 $
 ```
 
@@ -297,7 +297,7 @@ This can be used with email values also.
 
 ### About /certificates and certtoken
 
-The *CF_API_CERTKEY* or *certtoken* values are used for the Origin-CA */certificates* API calls.
+The *CLOUDFLARE_API_CERTKEY* or *certtoken* values are used for the Origin-CA */certificates* API calls.
 You can leave *certtoken* in the configuration with a blank value (or omit the option variable fully).
 
 The *extras* values are used when adding API calls outside of the core codebase.
@@ -426,7 +426,7 @@ Next a simple/single error response.
 This is simulated by providing incorrect authentication information.
 
 ```
-$ CF_API_EMAIL='someone@example.com' cli4 /zones/
+$ CLOUDFLARE_EMAIL='someone@example.com' cli4 /zones/
 cli4: /zones - 9103 Unknown X-Auth-Key or X-Auth-Email
 $
 ```


### PR DESCRIPTION
Updates all references and usage of environment variables from `CF_`
prefix to `CLOUDFLARE_` should they be present. This follows suit of the
other SDKs and tooling in the Cloudflare ecosystem allowing reuse of
credentials between them all.

A full prefix was chosen to avoid conflicts and potential leaking of
details between other tools that use the `CF_` prefix.

Eventually, we will aim to deprecate the `CF_` lookups entirely but for
now, just prefer them if they are present.