### PR TITLE
Make RegEx string a raw string literal

### DIFF
--- a/CloudFlare/api_decode_from_openapi.py
+++ b/CloudFlare/api_decode_from_openapi.py
@@ -7,7 +7,7 @@ import json
 
 API_TYPES = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']
 
-match_identifier = re.compile('\{[A-Za-z0-9_]*\}')
+match_identifier = re.compile(r'\{[A-Za-z0-9_]*\}')
 
 def do_path(cmd, values):
     """ do_path() """


### PR DESCRIPTION
`CloudFlare.api_decode_from_openapi.py::match_identifier` tries to escape `{` and `}` in the RegEx, but doesn't escape the backslash in the Python string literal. 

This PR just changes the string literal to be a raw string literal by prefixing it with `r` so Python doesn't try to interpret any escape sequences in the string.