### PR TITLE
Fix UnicodeDecodeError when installing, Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ _version_re = re.compile(r"__version__\s=\s'(.*)'")
 def main():
     """Cloudflare API code - setup.py file"""
 
-    with open('README.md') as read_me:
+    with open('README.md', encoding="utf-8") as read_me:
         long_description = read_me.read()
 
     with open('CloudFlare/__init__.py', 'r') as f:


### PR DESCRIPTION
When running `pip install cloudflare` on Windows with python 3.11,  throw error:
```
Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\Daic\AppData\Local\Temp\pip-install-bhkzeuqm\cloudflare_adb441c38e9e43e48350d8f689fe8bef\setup.py", line 49, in <module>
          main()
        File "C:\Users\Daic\AppData\Local\Temp\pip-install-bhkzeuqm\cloudflare_adb441c38e9e43e48350d8f689fe8bef\setup.py", line 13, in main
          long_description = read_me.read()
                             ^^^^^^^^^^^^^^
      UnicodeDecodeError: 'gbk' codec can't decode byte 0x88 in position 16820: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```