### PR TITLE
output major version release imminent warning

### DIFF
--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -18,30 +18,13 @@ from .api_v4 import api_v4
 from .api_extras import api_extras
 from .api_decode_from_openapi import api_decode_from_openapi
 from .exceptions import CloudFlareAPIError, CloudFlareInternalError
+from .warning_2_20 import warning_2_20, print_warning_2_20
 
 BASE_URL = 'https://api.cloudflare.com/client/v4'
 OPENAPI_URL = 'https://github.com/cloudflare/api-schemas/raw/main/openapi.json'
 
 DEFAULT_GLOBAL_REQUEST_TIMEOUT = 5
 DEFAULT_MAX_REQUEST_RETRIES = 5
-
-MAJOR_VERSION_WARNING = """
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  WARNING  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!                                                                            !!
-!! You are seeing this warning because you have upgraded to a version that is !!
-!! not intended to be installed.                                              !!
-!!                                                                            !!
-!! This version only exists to catch any accidental upgrades before we        !!
-!! release a major release.                                                   !!
-!!                                                                            !!
-!! You should determine if you need to revert this upgrade and pin to v2.19.* !!
-!! or if you can upgrade to v3.x.                                             !!
-!!                                                                            !!
-!! To see more about upgrading to next major version, please see              !!
-!! https://github.com/cloudflare/python-cloudflare/discussions/191            !!
-!!                                                                            !!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-"""
 
 class CloudFlare():
     """ A Python interface Cloudflare's v4 API.
@@ -68,7 +51,6 @@ class CloudFlare():
 
         def __init__(self, config):
             """ :meta private: """
-            print(MAJOR_VERSION_WARNING)
 
             self.network = None
             self.config = config
@@ -106,6 +88,13 @@ class CloudFlare():
             self.user_agent = user_agent()
 
             self.logger = CFlogger(config['debug']).getLogger() if 'debug' in config and config['debug'] else None
+
+            warning = warning_2_20()
+            if warning:
+                if self.logger:
+                    self.logger.warning('\n' + warning)
+                else:
+                    print_warning_2_20(warning)
 
         def __del__(self):
             if self.network:
@@ -297,7 +286,6 @@ class CloudFlare():
 
         def _call_network(self, method, headers, parts, identifiers, params, data_str, data_json, files):
             """ Cloudflare v4 API"""
-            print(MAJOR_VERSION_WARNING)
 
             if (method is None) or (parts[0] is None):
                 # should never happen

--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -49,7 +49,7 @@ class CloudFlare():
     class _v4base():
         """ :meta private: """
 
-        def __init__(self, config):
+        def __init__(self, config, warnings=True):
             """ :meta private: """
 
             self.network = None
@@ -89,12 +89,14 @@ class CloudFlare():
 
             self.logger = CFlogger(config['debug']).getLogger() if 'debug' in config and config['debug'] else None
 
-            warning = warning_2_20()
-            if warning:
-                if self.logger:
-                    self.logger.warning('\n' + warning)
-                else:
-                    print_warning_2_20(warning)
+            if warnings:
+                # After 2.20.* there is a warning message posted to handle un-pinned versions
+                warning = warning_2_20()
+                if warning:
+                    if self.logger:
+                        self.logger.warning(''.join(['\n       ' + v for v in warning.split('\n')]))
+                    else:
+                        print_warning_2_20(warning)
 
         def __del__(self):
             if self.network:
@@ -1032,7 +1034,7 @@ class CloudFlare():
 
         return self._base.api_from_openapi(url)
 
-    def __init__(self, email=None, key=None, token=None, certtoken=None, debug=False, raw=False, use_sessions=True, profile=None, base_url=None, global_request_timeout=None, max_request_retries=None, http_headers=None):
+    def __init__(self, email=None, key=None, token=None, certtoken=None, debug=False, raw=False, use_sessions=True, profile=None, base_url=None, global_request_timeout=None, max_request_retries=None, http_headers=None, warnings=True):
         """ :meta private: """
 
         self._base = None
@@ -1093,7 +1095,7 @@ class CloudFlare():
             if v == '':
                 config[k] = None
 
-        self._base = self._v4base(config)
+        self._base = self._v4base(config, warnings=warnings)
 
         # add the API calls
         try:

--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -25,6 +25,24 @@ OPENAPI_URL = 'https://github.com/cloudflare/api-schemas/raw/main/openapi.json'
 DEFAULT_GLOBAL_REQUEST_TIMEOUT = 5
 DEFAULT_MAX_REQUEST_RETRIES = 5
 
+MAJOR_VERSION_WARNING = """
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  WARNING  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!                                                                            !!
+!! You are seeing this warning because you have upgraded to a version that is !!
+!! not intended to be installed.                                              !!
+!!                                                                            !!
+!! This version only exists to catch any accidental upgrades before we        !!
+!! release a major release.                                                   !!
+!!                                                                            !!
+!! You should determine if you need to revert this upgrade and pin to v2.19.* !!
+!! or if you can upgrade to v3.x.                                             !!
+!!                                                                            !!
+!! To see more about upgrading to next major version, please see              !!
+!! https://github.com/cloudflare/python-cloudflare/discussions/191            !!
+!!                                                                            !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+"""
+
 class CloudFlare():
     """ A Python interface Cloudflare's v4 API.
 
@@ -50,6 +68,7 @@ class CloudFlare():
 
         def __init__(self, config):
             """ :meta private: """
+            print(MAJOR_VERSION_WARNING)
 
             self.network = None
             self.config = config
@@ -278,6 +297,7 @@ class CloudFlare():
 
         def _call_network(self, method, headers, parts, identifiers, params, data_str, data_json, files):
             """ Cloudflare v4 API"""
+            print(MAJOR_VERSION_WARNING)
 
             if (method is None) or (parts[0] is None):
                 # should never happen

--- a/CloudFlare/warning_2_20.py
+++ b/CloudFlare/warning_2_20.py
@@ -1,0 +1,31 @@
+""" warning message if version is 2.20 or above (technically, there's no version above 2.20.0) """
+
+import sys
+
+from . import __version__
+
+MAJOR_VERSION_WARNING = """\
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   WARNING  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! You're seeing this warning because you've upgraded the Python package 'cloudflare' to version  !!
+!! 2.20.* via an automated upgrade without version pinning. Version 2.20.0 exists to catch any    !!
+!! of these upgrades before Cloudflare releases a new major release under the release number 3.x. !!
+!!                                                                                                !!
+!! Should you determine that you need to revert this upgrade and pin to v2.19.* it is recommended !!
+!! you do the following: pip install --upgrade cloudflare==2.19.* or equivilant.                  !!
+!!                                                                                                !!
+!! Or you can upgrade to v3.x. NOTE: Release 3.x will not be code-compatible or call-compatible   !!
+!! with previous releases. To see more about upgrading to next major version, please see:         !!
+!! https://github.com/cloudflare/python-cloudflare/discussions/191                                !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\
+"""
+
+def warning_2_20():
+    """ warning_2_20 """
+
+    if __version__ < '2.20.0':
+        return None
+    return MAJOR_VERSION_WARNING
+
+def print_warning_2_20(warning):
+    """ print_warning_2_20 """
+    print(warning, file=sys.stderr)

--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ $ cli4 [-V|--version] [-h|--help] [-v|--verbose] \
     [-b|--binary] \
     [-p|--profile profile-name] \
     [-h|--header additional-header] \
+    [-w|--warnings [True|False]] \
     [--get|--patch|--post|--put|--delete] \
     [item=value|item=@filename|@filename ...] /command ...
 ```

--- a/cli4/cli4.py
+++ b/cli4/cli4.py
@@ -397,6 +397,7 @@ def do_it(args):
     binary_file = False
     profile = None
     http_headers = None
+    warnings = True
     method = 'GET'
 
     usage = ('usage: cli4 '
@@ -410,13 +411,14 @@ def do_it(args):
              + '[-b|--binary] '
              + '[-p|--profile profile-name] '
              + '[-h|--header additional-header] '
+             + '[-w|--warnings [True|False]] '
              + '[--get|--patch|--post|--put|--delete] '
              + '[item=value|item=@filename|@filename ...] '
              + '/command ...')
 
     try:
         opts, args = getopt.getopt(args,
-                                   'VhveqjynirdA:bp:h:GPOUD',
+                                   'VhveqjynirdA:bp:h:w:GPOUD',
                                    [
                                        'version', 'help', 'verbose',
                                        'examples',
@@ -428,6 +430,7 @@ def do_it(args):
                                        'binary',
                                        'profile=',
                                        'header=',
+                                       'warnings=',
                                        'get', 'patch', 'post', 'put', 'delete'
                                    ])
     except getopt.GetoptError:
@@ -461,6 +464,15 @@ def do_it(args):
             if http_headers is None:
                 http_headers = []
             http_headers.append(arg)
+        elif opt in ('-w', '--warnings'):
+            if arg is None or arg == '':
+                warnings = None
+            elif arg.lower() in ('yes', 'true', '1'):
+                warnings = True
+            elif arg.lower() in ('no', 'false', '0'):
+                warnings = False
+            else:
+                sys.exit('cli4: --warnings takes boolean True/False argument')
         elif opt in ('-d', '--dump'):
             do_dump = True
         elif opt in ('-A', '--openapi'):
@@ -487,7 +499,7 @@ def do_it(args):
         sys.exit(0)
 
     try:
-        cf = CloudFlare.CloudFlare(debug=verbose, raw=raw, profile=profile, http_headers=http_headers)
+        cf = CloudFlare.CloudFlare(debug=verbose, raw=raw, profile=profile, http_headers=http_headers, warnings=warnings)
     except Exception as e:
         sys.exit(e)
 


### PR DESCRIPTION
Updates the library to spew out a warning when the client is initialised and when an API call is invoked.

This is intentionally annoying and not scoped to stderr to ensure that if anyone does upgrade, they are quickly notified without any impediments.

This PR should be merged and then version 2.20 release on May 5th 2024.

cc @mahtin 